### PR TITLE
Automatically use fast diagonal filter, sample, and smoothing code when possible

### DIFF
--- a/examples/diagonal_gibbs.py
+++ b/examples/diagonal_gibbs.py
@@ -23,9 +23,8 @@ A = 0.99*np.array([[np.cos(np.pi/24), -np.sin(np.pi/24)],
                    [np.sin(np.pi/24),  np.cos(np.pi/24)]])
 sigma_states = 0.01*np.eye(2)
 
-# C = np.array([[10.,0.]])
-C = np.random.randn(D_obs, D_latent)
-sigma_obs = 0.1*np.eye(D_obs)
+C = np.array([[10.,0.]])
+sigma_obs = 0.01*np.eye(D_obs)
 
 
 ###################
@@ -47,42 +46,51 @@ def update(model):
     model.resample_model()
     return model.log_likelihood()
 
-model = LDS(
+diag_model = LDS(
     dynamics_distn=AutoRegression(
-            nu_0=D_latent+1,
+            nu_0=D_latent+3,
             S_0=D_latent*np.eye(D_latent),
             M_0=np.zeros((D_latent, D_latent)),
             K_0=D_latent*np.eye(D_latent)),
     emission_distn=DiagonalRegression(D_obs, D_latent))
 
-model.add_data(data)
+diag_model.add_data(data)
 
-lls = [update(model) for _ in progprint_xrange(100)]
+full_model = model = DefaultLDS(n=2,p=data.shape[1]).add_data(data)
+
+diag_lls = [update(diag_model) for _ in progprint_xrange(200)]
+full_lls = [update(full_model) for _ in progprint_xrange(200)]
 
 plt.figure(figsize=(3,4))
-plt.plot(lls)
+plt.plot(diag_lls, label="diagonal")
+plt.plot(full_lls, label="full")
 plt.xlabel('iteration')
 plt.ylabel('log likelihood')
+plt.legend()
 
 ################
 #  smoothing   #
 ################
-smoothed_obs = model.smooth(data)
+smoothed_obs = diag_model.smooth(data)
 
 ################
 #  predicting  #
 ################
-
+Nseed = 1700
 Npredict = 100
-prediction_seed = data[:1900]
+prediction_seed = data[:Nseed]
 
-predictions = model.sample_predictions(
+diag_preds = diag_model.sample_predictions(
+    prediction_seed, Npredict, obs_noise=False)
+
+full_preds = full_model.sample_predictions(
     prediction_seed, Npredict, obs_noise=False)
 
 plt.figure()
-plt.plot(data, 'b-')
-plt.plot(smoothed_obs, 'r-')
-plt.plot(prediction_seed.shape[0] + np.arange(Npredict), predictions, 'g--')
+plt.plot(data, 'k-')
+plt.plot(smoothed_obs[:Nseed], ':k')
+plt.plot(Nseed + np.arange(Npredict), diag_preds, 'b')
+plt.plot(Nseed + np.arange(Npredict), full_preds, 'r')
 plt.xlabel('time index')
 plt.ylabel('prediction')
 # plt.xlim(1800,2000)

--- a/examples/diagonal_meanfield.py
+++ b/examples/diagonal_meanfield.py
@@ -1,0 +1,90 @@
+from __future__ import division
+import numpy as np
+import numpy.random as npr
+import matplotlib.pyplot as plt
+
+from pybasicbayes.distributions import Regression, AutoRegression, DiagonalRegression
+from pybasicbayes.util.text import progprint_xrange
+
+from pylds.models import LDS, DefaultLDS
+
+npr.seed(0)
+
+
+#########################
+#  set some parameters  #
+#########################
+D_obs, D_latent = 1, 2
+mu_init = np.array([0.,1.])
+sigma_init = 0.01*np.eye(2)
+
+A = 0.99*np.array([[np.cos(np.pi/24), -np.sin(np.pi/24)],
+                   [np.sin(np.pi/24), np.cos(np.pi/24)]])
+sigma_states = 0.01*np.eye(2)
+
+C = np.array([[10.,0.]])
+sigma_obs = 0.01*np.eye(1)
+
+
+###################
+#  generate data  #
+###################
+
+truemodel = LDS(
+    dynamics_distn=AutoRegression(
+            A=A,sigma=sigma_states),
+    emission_distn=DiagonalRegression(
+            D_obs, D_latent, A=C, sigmasq=np.diag(sigma_obs)))
+
+data, stateseq = truemodel.generate(2000)
+
+
+###############
+#  fit model  #
+###############
+model = LDS(
+    dynamics_distn=AutoRegression(
+            nu_0=D_latent+1,
+            S_0=D_latent*np.eye(D_latent),
+            M_0=np.zeros((D_latent, D_latent)),
+            K_0=D_latent*np.eye(D_latent)),
+    emission_distn=DiagonalRegression(D_obs, D_latent))
+model.add_data(data)
+
+def update(model):
+    return model.meanfield_coordinate_descent_step()
+
+for _ in progprint_xrange(1):
+    model.resample_model()
+
+vlbs = [update(model) for _ in progprint_xrange(100)]
+
+plt.figure(figsize=(3,4))
+plt.plot(vlbs)
+plt.xlabel('iteration')
+plt.ylabel('variational lower bound')
+
+
+################
+#  smoothing   #
+################
+model.emission_distn.resample_from_mf()
+smoothed_obs = model.smooth(data)
+
+################
+#  predicting  #
+################
+
+Npredict = 100
+prediction_seed = data[:1700]
+
+predictions = model.sample_predictions(prediction_seed, Npredict)
+
+plt.figure()
+plt.plot(data, 'b-')
+plt.plot(smoothed_obs, 'r-')
+plt.plot(prediction_seed.shape[0] + np.arange(Npredict), predictions, 'g--')
+plt.xlabel('time index')
+plt.ylabel('prediction')
+
+plt.show()

--- a/examples/diagonal_meanfield.py
+++ b/examples/diagonal_meanfield.py
@@ -54,7 +54,7 @@ model.add_data(data)
 def update(model):
     return model.meanfield_coordinate_descent_step()
 
-for _ in progprint_xrange(1):
+for _ in progprint_xrange(100):
     model.resample_model()
 
 vlbs = [update(model) for _ in progprint_xrange(100)]
@@ -68,8 +68,9 @@ plt.ylabel('variational lower bound')
 ################
 #  smoothing   #
 ################
-model.emission_distn.resample_from_mf()
-smoothed_obs = model.smooth(data)
+# model.emission_distn.resample_from_mf()
+E_C,_,_,_ = model.emission_distn.mf_expectations
+smoothed_obs = model.states_list[0].smoothed_mus.dot(E_C.T)
 
 ################
 #  predicting  #

--- a/examples/diagonal_meanfield.py
+++ b/examples/diagonal_meanfield.py
@@ -68,23 +68,23 @@ plt.ylabel('variational lower bound')
 ################
 #  smoothing   #
 ################
-# model.emission_distn.resample_from_mf()
 E_C,_,_,_ = model.emission_distn.mf_expectations
 smoothed_obs = model.states_list[0].smoothed_mus.dot(E_C.T)
 
 ################
 #  predicting  #
 ################
-
+Nseed = 1700
 Npredict = 100
-prediction_seed = data[:1700]
+prediction_seed = data[:Nseed]
 
+model.emission_distn.resample_from_mf()
 predictions = model.sample_predictions(prediction_seed, Npredict)
 
 plt.figure()
-plt.plot(data, 'b-')
-plt.plot(smoothed_obs, 'r-')
-plt.plot(prediction_seed.shape[0] + np.arange(Npredict), predictions, 'g--')
+plt.plot(data, 'k')
+plt.plot(smoothed_obs[:Nseed], ':k')
+plt.plot(Nseed + np.arange(Npredict), predictions, 'b')
 plt.xlabel('time index')
 plt.ylabel('prediction')
 

--- a/pylds/states.py
+++ b/pylds/states.py
@@ -216,16 +216,12 @@ class LDSStates(object):
         J_init = np.linalg.inv(self.sigma_init)
         h_init = np.linalg.solve(self.sigma_init, self.mu_init)
 
-        # TODO: Make this support other regression distributions
-        # TODO: E.g. make expected stats a property of the distribution?
-        assert not self.diagonal_noise
-        def get_params(distn):
-            return mniw_expectedstats(
-                *distn._natural_to_standard(distn.mf_natural_hypparam))
-
         J_pair_22, J_pair_21, J_pair_11, logdet_pair = \
-            get_params(self.dynamics_distn)
-        J_yy, J_yx, J_node, logdet_node = get_params(self.emission_distn)
+            self.dynamics_distn.meanfield_expectedstats()
+
+        J_yy, J_yx, J_node, logdet_node = \
+            self.emission_distn.meanfield_expectedstats()
+
         h_node = self.data.dot(J_yx)
 
         self._normalizer, self.smoothed_mus, self.smoothed_sigmas, \

--- a/pylds/states.py
+++ b/pylds/states.py
@@ -227,6 +227,7 @@ class LDSStates(object):
         self._normalizer, self.smoothed_mus, self.smoothed_sigmas, \
             E_xtp1_xtT = info_E_step(
                 J_init,h_init,J_pair_11,-J_pair_21,J_pair_22,J_node,h_node)
+
         self._normalizer += self._info_extra_loglike_terms(
             J_init, h_init, logdet_pair, J_yy, logdet_node, self.data)
 

--- a/pylds/states.py
+++ b/pylds/states.py
@@ -5,7 +5,7 @@ from pybasicbayes.util.general import AR_striding
 from pybasicbayes.util.stats import mniw_expectedstats
 
 from lds_messages_interface import kalman_filter, filter_and_sample, E_step, \
-    info_E_step
+    info_E_step, filter_and_sample_diagonal, kalman_filter_diagonal
 
 
 class LDSStates(object):
@@ -82,22 +82,41 @@ class LDSStates(object):
 
         return obs
 
-    ### filtering
+    ### filtering and smoothing
 
     def filter(self):
-        self._normalizer, self.filtered_mus, self.filtered_sigmas = \
-            kalman_filter(
-                self.mu_init, self.sigma_init,
-                self.A, self.sigma_states, self.C, self.sigma_obs,
-                self.data)
+        if self.diagonal_noise:
+            self._normalizer, self.filtered_mus, self.filtered_sigmas = \
+                kalman_filter_diagonal(
+                    self.mu_init, self.sigma_init,
+                    self.A, self.sigma_states, self.C, self.sigma_obs_flat,
+                    self.data)
+        else:
+            self._normalizer, self.filtered_mus, self.filtered_sigmas = \
+                kalman_filter(
+                    self.mu_init, self.sigma_init,
+                    self.A, self.sigma_states, self.C, self.sigma_obs,
+                    self.data)
+
+    def smooth(self):
+        # Use the info E step because it can take advantage of diagonal noise
+        # The standard E step could but we have not implemented it
+        self.info_E_step()
+        return self.smoothed_mus.dot(self.C.T)
 
     ### resampling
 
     def resample(self):
-        self._normalizer, self.stateseq = filter_and_sample(
-            self.mu_init, self.sigma_init,
-            self.A, self.sigma_states, self.C, self.sigma_obs,
-            self.data)
+        if self.diagonal_noise:
+            self._normalizer, self.stateseq = filter_and_sample_diagonal(
+                self.mu_init, self.sigma_init,
+                self.A, self.sigma_states, self.C, self.sigma_obs_flat,
+                self.data)
+        else:
+            self._normalizer, self.stateseq = filter_and_sample(
+                self.mu_init, self.sigma_init,
+                self.A, self.sigma_states, self.C, self.sigma_obs,
+                self.data)
 
     ### EM
 
@@ -154,8 +173,13 @@ class LDSStates(object):
         J_pair_21 = -np.linalg.solve(sigma_states, A)
         J_pair_22 = np.linalg.inv(sigma_states)
 
-        J_node = C.T.dot(np.linalg.solve(sigma_obs, C))
-        h_node = np.einsum('ik,ij,tj->tk', C, np.linalg.inv(sigma_obs), data)
+        # Check if diagonal and avoid inverting D_obs x D_obs matrix
+        if self.diagonal_noise:
+            J_node = (C.T * 1./ self.sigma_obs_flat).dot(C)
+            h_node = np.einsum('ik,i,ti->tk', C, 1./self.sigma_obs_flat, data)
+        else:
+            J_node = C.T.dot(np.linalg.solve(sigma_obs, C))
+            h_node = np.einsum('ik,ij,tj->tk', C, np.linalg.inv(sigma_obs), data)
 
         self._normalizer, self.smoothed_mus, self.smoothed_sigmas, \
             E_xtp1_xtT = info_E_step(
@@ -192,6 +216,9 @@ class LDSStates(object):
         J_init = np.linalg.inv(self.sigma_init)
         h_init = np.linalg.solve(self.sigma_init, self.mu_init)
 
+        # TODO: Make this support other regression distributions
+        # TODO: E.g. make expected stats a property of the distribution?
+        assert not self.diagonal_noise
         def get_params(distn):
             return mniw_expectedstats(
                 *distn._natural_to_standard(distn.mf_natural_hypparam))
@@ -245,6 +272,10 @@ class LDSStates(object):
         return self.model.emission_distn
 
     @property
+    def diagonal_noise(self):
+        return self.model.diagonal_noise
+
+    @property
     def dynamics_distn(self):
         return self.model.dynamics_distn
 
@@ -279,6 +310,10 @@ class LDSStates(object):
     @property
     def sigma_obs(self):
         return self.model.sigma_obs
+
+    @property
+    def sigma_obs_flat(self):
+        return self.model.sigma_obs_flat
 
     @property
     def strided_stateseq(self):


### PR DESCRIPTION
Now that the `DiagonalRegression` class has been added to pybasicbayes (https://github.com/mattjj/pybasicbayes/commit/4d535afdd5d453f73d0bdd92ba60e33e89812a7f) we can introduce a dependency on this class in pylds. If the observation matrix is an instance of `DiagonalRegression`, automatically use [filter_and_sample_diagonal](https://github.com/mattjj/pylds/blob/master/pylds/lds_messages.pyx#L270),  [kalman_filter_diagonal](https://github.com/mattjj/pylds/blob/master/pylds/lds_messages.pyx#L230), and [info_E_step](https://github.com/mattjj/pylds/blob/diagonal/pylds/states.py#L177), which can take advantage of the structure in the observation noise covariance. 